### PR TITLE
Prevent truncation of IPv6 addresses

### DIFF
--- a/app/StdinMailParser.php
+++ b/app/StdinMailParser.php
@@ -108,7 +108,7 @@ abstract class StdinMailParser
         $headerLines = explode(PHP_EOL, $this->_header);
         $headerArr   = [];
         foreach ($headerLines as $line) {
-            @list($key, $value) = explode(":", $line);
+            @list($key, $value) = explode(":", $line, 2);
             if (is_null($value)) {
                 // avoid 'PHP Notice:  Undefined offset: 1' on header line without colon
                 syslog(LOG_WARNING, sprintf('%s: Could not parse mail header line: %s', __METHOD__, $line));


### PR DESCRIPTION
Added a limit to explode() to prevent the truncation of IPv6 addresses in the x-meta-client header.
IPv6 addresses contain colons (":") which is also the separator character.